### PR TITLE
[code-infra] Fix type checking of display-name plugin

### DIFF
--- a/packages/babel-plugin-display-name/package.json
+++ b/packages/babel-plugin-display-name/package.json
@@ -23,6 +23,8 @@
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
+    "@types/babel__core": "^7.20.5",
+    "@types/babel__helper-plugin-utils": "^7.10.3",
     "prettier": "^2.7.1"
   },
   "peerDependencies": {

--- a/packages/babel-plugin-display-name/src/index.test.js
+++ b/packages/babel-plugin-display-name/src/index.test.js
@@ -1,8 +1,6 @@
-import path from 'path';
 import { transformSync } from '@babel/core';
 import { describe, it, expect } from 'vitest';
-
-const plugin = path.join(__dirname, './index.js');
+import plugin from './index';
 
 const transform = (code, pluginOptions) =>
   transformSync(code, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,12 @@ importers:
       '@babel/preset-react':
         specifier: ^7.18.6
         version: 7.27.1(@babel/core@7.26.0)
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
+      '@types/babel__helper-plugin-utils':
+        specifier: ^7.10.3
+        version: 7.10.3
       prettier:
         specifier: ^2.7.1
         version: 2.8.8
@@ -3323,6 +3329,9 @@ packages:
 
   '@types/babel__generator@7.6.8':
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+
+  '@types/babel__helper-plugin-utils@7.10.3':
+    resolution: {integrity: sha512-FcLBBPXInqKfULB2nvOBskQPcnSMZ0s1Y2q76u9H1NPPWaLcTeq38xBeKfF/RBUECK333qeaqRdYoPSwW7rTNQ==}
 
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
@@ -13327,6 +13336,10 @@ snapshots:
   '@types/babel__generator@7.6.8':
     dependencies:
       '@babel/types': 7.27.1
+
+  '@types/babel__helper-plugin-utils@7.10.3':
+    dependencies:
+      '@types/babel__core': 7.20.5
 
   '@types/babel__template@7.4.4':
     dependencies:


### PR DESCRIPTION
Add type checking to the plugin and fix the jsdoc. These are for the most part type only changes (added comments). I did add an extra `t.isIdentifier(node)` guard in there where it was obvious.

Pretty sure we can remove more of the type casts I added if we use the babel NodePath apis better, but I don't want this to turn into a full-on refactor, just adding type.