### PR TITLE
[benchmark] Refactor profiling onto a shared case runtime

### DIFF
--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -223,12 +223,12 @@ Each `benchmark()` case renders a toolbar pinned to the top of the page with **R
 3. Stop the recording and inspect. Toggle **Unmount** / **Render** to capture more frames, or **Run interaction** to profile a re-render.
 4. Click **Finish** to end the case and move to the next one.
 
-Filter to a single case with Vitest's `-t "<name>"` (or by file) so the window isn't shared across many cases. Profile runs drop the deterministic V8 flags and software rendering used for measurement (`--no-opt`, `--predictable`, `--disable-gpu`, …) so the numbers in the profiler reflect realistic performance; they are therefore not comparable to measurement-mode results.
+Filter to a single case with Vitest's `-t "<name>"` (or by file) so the window isn't shared across many cases. Profiling shares the same minimal launch args as measurement (V8 optimization and the GPU stay on for both), so the profiler reflects realistic performance; it differs only by running headed — DevTools open, in a full desktop viewport (below) — so its absolute numbers aren't directly comparable to a measurement run.
 
-Profile mode renders into a full desktop viewport (1920x1080 by default) and sizes the browser window to match, instead of Vitest's phone-sized 414x896 default. Set it to your screen resolution to fill the whole window, via the `profileViewport` option or the `BENCHMARK_PROFILE_VIEWPORT` env var:
+Both modes render at a 1920x1080 viewport by default (instead of Vitest's phone-sized 414x896). Set `viewport` (or the `BENCHMARK_VIEWPORT` env var) to change it; in profile mode the headed browser window is also sized to match so the full render is visible:
 
 ```bash
-BENCHMARK_PROFILE=true BENCHMARK_PROFILE_VIEWPORT=2560x1440 vitest run -t "MyComponent mount"
+BENCHMARK_PROFILE=true BENCHMARK_VIEWPORT=2560x1440 vitest run -t "MyComponent mount"
 ```
 
 Profile mode is also settable via the `profile` config option:
@@ -236,7 +236,7 @@ Profile mode is also settable via the `profile` config option:
 ```ts
 export default createBenchmarkVitestConfig({
   profile: true,
-  profileViewport: { width: 2560, height: 1440 },
+  viewport: { width: 2560, height: 1440 },
 });
 ```
 
@@ -248,7 +248,7 @@ export default createBenchmarkVitestConfig({
 - `baselinePath` — path to a prior results JSON file to inline as the comparison base (see [Baseline comparisons](#baseline-comparisons)). Also settable via `BENCHMARK_BASELINE_PATH`.
 - `launchArgs` — additional browser launch arguments
 - `profile` — run an interactive profiling session in a headed browser with DevTools instead of measuring (see [Profiling in DevTools](#profiling-in-devtools)). Also settable via `BENCHMARK_PROFILE=true`.
-- `profileViewport` — `{ width, height }` viewport (and window size) for profile mode (default: `1920x1080`). Also settable via `BENCHMARK_PROFILE_VIEWPORT` (e.g. `2560x1440`).
+- `viewport` — `{ width, height }` browser viewport (and window size in profile mode), applied to both modes. Defaults to `1920x1080`. Also settable via `BENCHMARK_VIEWPORT` (e.g. `2560x1440`).
 
 To override standard Vitest options (e.g. `include`, `testTimeout`, `headless`), use `mergeConfig`:
 

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { expect, it } from 'vitest';
 import * as ReactDOMClient from 'react-dom/client'; // aliased to react-dom/profiling by Vite
 import * as ReactDOM from 'react-dom';
-import type { RenderEvent, IterationData, InteractionContext } from './types';
+import type { RenderEvent, IterationData, InteractionContext, BenchmarkCaseRuntime } from './types';
 import { ElementTiming } from './ElementTiming';
 import { ScalarMetric } from './ScalarMetric';
 import { metricsGate } from './metricsGate';
 import { createReactRecordingControls, type ReactRecordingControls } from './reactRecording';
+import { runProfileSession } from './profileSession';
 // Import for TaskMeta augmentation side effect
 import './taskMetaAugmentation';
 
@@ -53,7 +54,6 @@ function BenchProfiler({
   return (
     <React.Profiler id="bench" onRender={onRender}>
       {children}
-      <ElementTiming name="default" />
     </React.Profiler>
   );
 }
@@ -85,21 +85,15 @@ function supportsElementTiming(): boolean {
   return PerformanceObserver.supportedEntryTypes.includes('element');
 }
 
-// When true, `benchmark()` opens an interactive profiling session in a headed
-// browser instead of running the automated measurement loop. Enabled by
-// `createBenchmarkVitestConfig({ profile: true })` or `BENCHMARK_PROFILE=true`,
-// both of which replace this expression at build time via Vite `define`.
-const PROFILE_MODE = process.env.BENCHMARK_PROFILE === 'true';
-
 interface ElementTimingWaiter {
   elementEntries: PerformanceElementTiming[];
   waitForElementTiming: (identifier: string, timeout?: number) => Promise<void>;
   disconnect: () => void;
 }
 
-// Sets up a PerformanceObserver for the Element Timing API and exposes a
-// promise-based `waitForElementTiming` helper. Shared by the measurement loop
-// and the interactive profiling session.
+// Sets up a PerformanceObserver for the Element Timing API and exposes a promise-based
+// `waitForElementTiming` helper. Used by the measurement loop (which also reads `elementEntries`
+// to record paint metrics) and the interactive profiling session.
 function createElementTimingWaiter(): ElementTimingWaiter {
   const hasElementTiming = supportsElementTiming();
   const elementEntries: PerformanceElementTiming[] = [];
@@ -161,6 +155,77 @@ function createElementTimingWaiter(): ElementTimingWaiter {
   };
 }
 
+// When true, `benchmark()` opens an interactive profiling session in a headed
+// browser instead of running the automated measurement loop. Enabled by
+// `createBenchmarkVitestConfig({ profile: true })` or `BENCHMARK_PROFILE=true`,
+// both of which replace this expression at build time via Vite `define`.
+const PROFILE_MODE = process.env.BENCHMARK_PROFILE === 'true';
+
+interface CreateCaseRuntimeOptions {
+  /**
+   * Produces the case to mount. Measurement passes a renderFn already wrapped in `<BenchProfiler>`
+   * to collect render events; profiling passes the case bare so the React Profiler overhead stays
+   * out of the hand-captured DevTools trace.
+   */
+  renderFn: () => React.ReactElement;
+  interaction?: (ctx: InteractionContext) => Promise<void> | void;
+  /**
+   * Context handed to the interaction callback. The driver assembles it: measurement supplies the
+   * real React recording controls, profiling supplies no-ops since the user drives DevTools by hand.
+   */
+  context: InteractionContext;
+  onUncaughtError?: (error: unknown) => void;
+}
+
+function createCaseRuntime({
+  renderFn,
+  interaction,
+  context,
+  onUncaughtError,
+}: CreateCaseRuntimeOptions): BenchmarkCaseRuntime {
+  let root: ReactDOMClient.Root | null = null;
+  let container: HTMLElement | null = null;
+
+  return {
+    mount() {
+      if (root) {
+        return;
+      }
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      const newRoot = ReactDOMClient.createRoot(container, { onUncaughtError });
+      root = newRoot;
+      ReactDOM.flushSync(() => {
+        newRoot.render(
+          <React.Fragment>
+            {renderFn()}
+            {/* Harness paint sentinel: emits the `default` Element Timing entry that
+                `waitForElementTiming('default')` waits on, in both measurement and profile mode.
+                Rendered as a sibling (outside renderFn / its BenchProfiler) so it isn't counted in
+                the measured render duration. */}
+            <ElementTiming name="default" />
+          </React.Fragment>,
+        );
+      });
+    },
+    interact: interaction
+      ? async () => {
+          await interaction(context);
+        }
+      : undefined,
+    unmount() {
+      if (!root) {
+        return;
+      }
+      root.unmount();
+      container?.remove();
+      root = null;
+      container = null;
+    },
+    isMounted: () => root !== null,
+  };
+}
+
 interface BenchmarkOptions {
   runs?: number;
   warmupRuns?: number;
@@ -173,161 +238,6 @@ interface BenchmarkOptions {
   reactRecordingPaused?: boolean;
 }
 
-const PROFILE_PANEL_STYLE = [
-  'position:fixed',
-  'top:0',
-  'left:0',
-  'right:0',
-  'z-index:2147483647',
-  'display:flex',
-  'gap:8px',
-  'align-items:center',
-  'box-sizing:border-box',
-  'padding:8px 12px',
-  'background:#1e1e1e',
-  'color:#fff',
-  'font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace',
-  'box-shadow:0 1px 6px rgba(0,0,0,0.5)',
-].join(';');
-
-const PROFILE_BUTTON_STYLE = [
-  'padding:4px 10px',
-  'border:1px solid #555',
-  'border-radius:4px',
-  'background:#333',
-  'color:#fff',
-  'cursor:pointer',
-  'font:inherit',
-].join(';');
-
-function createProfileButton(label: string): HTMLButtonElement {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.textContent = label;
-  button.style.cssText = PROFILE_BUTTON_STYLE;
-  return button;
-}
-
-// Interactive profiling session: instead of measuring, render a control panel
-// with Render / Unmount / Run interaction / Finish buttons. The component under
-// test stays unmounted until the user clicks "Render", giving them time to start
-// the DevTools profiler first. The returned promise resolves on "Finish", which
-// is what keeps the Vitest test (and the headed browser window) alive in between.
-function runProfileSession(
-  name: string,
-  renderFn: () => React.ReactElement,
-  interaction?: (ctx: InteractionContext) => Promise<void> | void,
-): Promise<void> {
-  const panel = document.createElement('div');
-  panel.setAttribute('data-benchmark-profile-panel', '');
-  panel.style.cssText = PROFILE_PANEL_STYLE;
-
-  const title = document.createElement('span');
-  title.textContent = `⏱ ${name}`;
-  title.style.cssText = 'font-weight:600;white-space:nowrap';
-
-  const status = document.createElement('span');
-  status.style.cssText = 'margin-left:auto;opacity:0.85;white-space:nowrap';
-
-  const renderButton = createProfileButton('▶ Render');
-  const interactButton = interaction ? createProfileButton('⚡ Run interaction') : null;
-  const finishButton = createProfileButton('✓ Finish');
-
-  if (interactButton) {
-    interactButton.disabled = true;
-  }
-
-  panel.appendChild(title);
-  panel.appendChild(renderButton);
-  if (interactButton) {
-    panel.appendChild(interactButton);
-  }
-  panel.appendChild(finishButton);
-  panel.appendChild(status);
-  document.body.appendChild(panel);
-
-  // Push page content below the fixed panel so it doesn't cover the component.
-  const spacer = document.createElement('div');
-  spacer.style.height = `${panel.offsetHeight}px`;
-  document.body.insertBefore(spacer, panel);
-
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-
-  const timing = createElementTimingWaiter();
-  let root: ReactDOMClient.Root | null = null;
-
-  const setStatus = (text: string) => {
-    status.textContent = text;
-  };
-
-  const show = () => {
-    if (root) {
-      return;
-    }
-    root = ReactDOMClient.createRoot(container);
-    ReactDOM.flushSync(() => {
-      root!.render(renderFn());
-    });
-    renderButton.textContent = '■ Unmount';
-    if (interactButton) {
-      interactButton.disabled = false;
-    }
-    setStatus('rendered — capture your profile, then Unmount or Finish');
-  };
-
-  const hide = () => {
-    if (!root) {
-      return;
-    }
-    root.unmount();
-    root = null;
-    renderButton.textContent = '▶ Render';
-    if (interactButton) {
-      interactButton.disabled = true;
-    }
-    setStatus('unmounted — Render again or Finish');
-  };
-
-  setStatus('idle — start the DevTools profiler, then click Render');
-
-  return new Promise<void>((resolve) => {
-    renderButton.addEventListener('click', () => (root ? hide() : show()));
-
-    if (interactButton && interaction) {
-      interactButton.addEventListener('click', async () => {
-        interactButton.disabled = true;
-        setStatus('running interaction…');
-        try {
-          await interaction({
-            waitForElementTiming: timing.waitForElementTiming,
-            // No harness recording in interactive profile mode — the user drives the DevTools
-            // profiler — so the recording controls are no-ops here.
-            pauseReactRecording: () => {},
-            resumeReactRecording: () => {},
-          });
-          setStatus('interaction done');
-        } catch (error) {
-          setStatus(`interaction error: ${String(error)}`);
-        } finally {
-          if (root) {
-            interactButton.disabled = false;
-          }
-        }
-      });
-    }
-
-    finishButton.addEventListener('click', () => {
-      hide();
-      timing.disconnect();
-      spacer.remove();
-      container.remove();
-      panel.remove();
-      resolve();
-    });
-  });
-}
-
 export function benchmark(
   name: string,
   renderFn: () => React.ReactElement,
@@ -337,11 +247,26 @@ export function benchmark(
   const interaction = typeof interactionOrOptions === 'function' ? interactionOrOptions : undefined;
   const options = typeof interactionOrOptions === 'object' ? interactionOrOptions : maybeOptions;
 
-  // In profile mode, skip the automated measurement loop entirely and hand the
-  // case to an interactive session so a human can drive the DevTools profiler.
+  // In profile mode, skip the automated measurement loop entirely: build a bare case runtime (no
+  // BenchProfiler wrapper, no-op recording since the user drives DevTools by hand) and hand it to
+  // the interactive panel.
   if (PROFILE_MODE) {
     it(name, async () => {
-      await runProfileSession(name, renderFn, interaction);
+      const timing = createElementTimingWaiter();
+      // No `wrap`: profile mode renders the component bare (no BenchProfiler / React Profiler
+      // overhead in the hand-captured trace). The runtime still plants the `default` sentinel, so
+      // the first paint shows up as a labeled marker in the DevTools Performance timeline.
+      const runtime = createCaseRuntime({
+        renderFn,
+        interaction,
+        context: {
+          waitForElementTiming: timing.waitForElementTiming,
+          pauseReactRecording: () => {},
+          resumeReactRecording: () => {},
+        },
+      });
+      await runProfileSession(name, runtime);
+      timing.disconnect();
     });
     return;
   }
@@ -362,7 +287,6 @@ export function benchmark(
       format: { style: 'unit', unit: 'millisecond', maximumFractionDigits: 2 },
       alarm: { error: 0.2 },
     });
-
 
     if (typeof window.gc !== 'function') {
       console.warn(
@@ -391,47 +315,44 @@ export function benchmark(
       forceGC();
 
       const captures: RenderEvent[] = [];
-      const { elementEntries, waitForElementTiming, disconnect } = createElementTimingWaiter();
+      const timing = createElementTimingWaiter();
 
-      const iterationStart = performance.now();
-
-      const container = document.createElement('div');
-      document.body.appendChild(container);
-
-      const root = ReactDOMClient.createRoot(container, {
+      const runtime = createCaseRuntime({
+        // Wrap the case in BenchProfiler so its renders are captured; the runtime mounts whatever
+        // renderFn returns (profiling passes the case bare).
+        renderFn: () => (
+          <BenchProfiler captures={captures} recording={recording}>
+            {renderFn()}
+          </BenchProfiler>
+        ),
+        interaction,
+        context: {
+          waitForElementTiming: timing.waitForElementTiming,
+          pauseReactRecording: recording.pauseReactRecording,
+          resumeReactRecording: recording.resumeReactRecording,
+        },
         // eslint-disable-next-line @typescript-eslint/no-loop-func
         onUncaughtError: (error) => {
           renderError = error;
         },
       });
 
-      ReactDOM.flushSync(() => {
-        root.render(
-          <BenchProfiler captures={captures} recording={recording}>
-            {renderFn()}
-          </BenchProfiler>,
-        );
-      });
+      const iterationStart = performance.now();
+
+      runtime.mount();
 
       if (renderError) {
-        disconnect();
-        root.unmount();
-        container.remove();
+        timing.disconnect();
+        runtime.unmount();
         break;
       }
 
-      if (interaction) {
-        // eslint-disable-next-line no-await-in-loop
-        await interaction({
-          waitForElementTiming,
-          pauseReactRecording: recording.pauseReactRecording,
-          resumeReactRecording: recording.resumeReactRecording,
-        });
-      }
+      // eslint-disable-next-line no-await-in-loop
+      await runtime.interact?.();
 
       // Wait for the bench sentinel paint entry (relies on test timeout)
       // eslint-disable-next-line no-await-in-loop
-      await waitForElementTiming('default', 0);
+      await timing.waitForElementTiming('default', 0);
 
       // Close the final window and remember if any active window measured no renders.
       recording.finalizeWindow();
@@ -439,13 +360,12 @@ export function benchmark(
         sawEmptyActiveWindow = true;
       }
 
-      disconnect();
+      timing.disconnect();
 
-      root.unmount();
-      container.remove();
+      runtime.unmount();
 
       if (!isWarmup) {
-        for (const entry of elementEntries) {
+        for (const entry of timing.elementEntries) {
           // Skip paints that happened while recording was paused. Attribute by the paint's
           // `renderTime`, not by when the observer callback fired (which can lag the paint).
           if (!recording.activeAt(entry.renderTime)) {

--- a/packages/benchmark/src/profileSession.tsx
+++ b/packages/benchmark/src/profileSession.tsx
@@ -1,0 +1,134 @@
+import type { BenchmarkCaseRuntime } from './types';
+
+const PROFILE_PANEL_STYLE = [
+  'position:fixed',
+  'top:0',
+  'left:0',
+  'right:0',
+  'z-index:2147483647',
+  'display:flex',
+  'gap:8px',
+  'align-items:center',
+  'box-sizing:border-box',
+  'padding:8px 12px',
+  'background:#1e1e1e',
+  'color:#fff',
+  'font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace',
+  'box-shadow:0 1px 6px rgba(0,0,0,0.5)',
+].join(';');
+
+const PROFILE_BUTTON_STYLE = [
+  'padding:4px 10px',
+  'border:1px solid #555',
+  'border-radius:4px',
+  'background:#333',
+  'color:#fff',
+  'cursor:pointer',
+  'font:inherit',
+].join(';');
+
+function createProfileButton(label: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = label;
+  button.style.cssText = PROFILE_BUTTON_STYLE;
+  return button;
+}
+
+// Interactive profiling session: instead of measuring, render a control panel with
+// Render / Unmount / Run interaction / Finish buttons that drive the given case runtime. The
+// component under test stays unmounted until the user clicks "Render", giving them time to start
+// the DevTools profiler first. The returned promise resolves on "Finish", which is what keeps the
+// Vitest test (and the headed browser window) alive in between; the caller cleans up afterwards.
+export function runProfileSession(name: string, runtime: BenchmarkCaseRuntime): Promise<void> {
+  const panel = document.createElement('div');
+  panel.setAttribute('data-benchmark-profile-panel', '');
+  panel.style.cssText = PROFILE_PANEL_STYLE;
+
+  const title = document.createElement('span');
+  title.textContent = `⏱ ${name}`;
+  title.style.cssText = 'font-weight:600;white-space:nowrap';
+
+  const status = document.createElement('span');
+  status.style.cssText = 'margin-left:auto;opacity:0.85;white-space:nowrap';
+
+  const renderButton = createProfileButton('▶ Render');
+  const interactButton = runtime.interact ? createProfileButton('⚡ Run interaction') : null;
+  const finishButton = createProfileButton('✓ Finish');
+
+  if (interactButton) {
+    interactButton.disabled = true;
+  }
+
+  panel.appendChild(title);
+  panel.appendChild(renderButton);
+  if (interactButton) {
+    panel.appendChild(interactButton);
+  }
+  panel.appendChild(finishButton);
+  panel.appendChild(status);
+  document.body.appendChild(panel);
+
+  // Push page content below the fixed panel so it doesn't cover the component.
+  const spacer = document.createElement('div');
+  spacer.style.height = `${panel.offsetHeight}px`;
+  document.body.insertBefore(spacer, panel);
+
+  const setStatus = (text: string) => {
+    status.textContent = text;
+  };
+
+  const show = () => {
+    if (runtime.isMounted()) {
+      return;
+    }
+    runtime.mount();
+    renderButton.textContent = '■ Unmount';
+    if (interactButton) {
+      interactButton.disabled = false;
+    }
+    setStatus('rendered — capture your profile, then Unmount or Finish');
+  };
+
+  const hide = () => {
+    if (!runtime.isMounted()) {
+      return;
+    }
+    runtime.unmount();
+    renderButton.textContent = '▶ Render';
+    if (interactButton) {
+      interactButton.disabled = true;
+    }
+    setStatus('unmounted — Render again or Finish');
+  };
+
+  setStatus('idle — start the DevTools profiler, then click Render');
+
+  return new Promise<void>((resolve) => {
+    renderButton.addEventListener('click', () => (runtime.isMounted() ? hide() : show()));
+
+    if (interactButton) {
+      interactButton.addEventListener('click', async () => {
+        interactButton.disabled = true;
+        setStatus('running interaction…');
+        try {
+          await runtime.interact?.();
+          setStatus('interaction done');
+        } catch (error) {
+          setStatus(`interaction error: ${String(error)}`);
+        } finally {
+          if (runtime.isMounted()) {
+            interactButton.disabled = false;
+          }
+        }
+      });
+    }
+
+    finishButton.addEventListener('click', () => {
+      hide();
+      spacer.remove();
+      panel.remove();
+      resolve();
+    });
+  });
+}

--- a/packages/benchmark/src/types.ts
+++ b/packages/benchmark/src/types.ts
@@ -37,6 +37,19 @@ export interface InteractionContext {
   resumeReactRecording: () => void;
 }
 
+// One benchmark case's lifecycle. The measurement loop creates one per iteration and drives it
+// automatically; the interactive profiling session creates one and drives it from buttons.
+export interface BenchmarkCaseRuntime {
+  mount: () => void;
+  /**
+   * Runs the case's interaction with the harness context. Absent when the case has no interaction —
+   * the profiling panel uses its presence to decide whether to show the "Run interaction" button.
+   */
+  interact?: () => Promise<void>;
+  unmount: () => void;
+  isMounted: () => boolean;
+}
+
 /**
  * Whether a custom metric measures a continuous value or a discrete count.
  * - `scalar` — continuous measurements (timings, sizes); compared with a relative noise band.

--- a/packages/benchmark/src/vitest.ts
+++ b/packages/benchmark/src/vitest.ts
@@ -22,69 +22,52 @@ export interface CreateBenchmarkVitestConfigOptions {
    * Run each `benchmark()` case as an interactive profiling session in a headed
    * browser instead of the automated measurement loop. Each case renders a
    * control panel with Render / Unmount / Finish buttons so you can start the
-   * DevTools profiler before the component mounts. The deterministic V8 flags
-   * and software rendering used for measurement are dropped so the numbers in
-   * the profiler reflect realistic performance. Also settable via
+   * DevTools profiler before the component mounts. Profiling auto-opens DevTools
+   * and runs headed (pass `viewport` to size the window). Also settable via
    * `BENCHMARK_PROFILE=true`.
    */
   profile?: boolean;
   /**
-   * Viewport (and matching browser window size) used in profile mode. Vitest's
-   * default browser viewport is a phone-sized 414x896; profiling overrides it
-   * with a full desktop viewport so the component renders at a realistic size.
-   * Set this to your screen's resolution to fill the whole window. Also settable
-   * via `BENCHMARK_PROFILE_VIEWPORT` (e.g. `2560x1440`). Defaults to 1920x1080.
+   * Browser viewport — and, in profile mode, the matching window size. Defaults to 1920x1080 for
+   * both measurement and profiling. Also settable via `BENCHMARK_VIEWPORT` (e.g. `2560x1440`).
    */
-  profileViewport?: { width: number; height: number };
+  viewport?: { width: number; height: number };
 }
 
-// Resolves the profile-mode viewport from the option, the
-// `BENCHMARK_PROFILE_VIEWPORT` env var (`<width>x<height>`), or a 1920x1080
-// default.
-function resolveProfileViewport(option?: { width: number; height: number }): {
+// Default viewport for all benchmark runs (measurement and profiling alike) — a desktop size is
+// more representative for component benchmarks than Vitest's phone-sized 414x896 browser default.
+const DEFAULT_VIEWPORT = { width: 1920, height: 1080 };
+
+// Explicit viewport from the `viewport` option or the `BENCHMARK_VIEWPORT` env var
+// (`<width>x<height>`); undefined when neither is set, so the caller can apply the default.
+function resolveViewport(option?: {
   width: number;
   height: number;
-} {
+}): { width: number; height: number } | undefined {
   if (option) {
     return option;
   }
-  const env = process.env.BENCHMARK_PROFILE_VIEWPORT;
-  const match = env ? /^\s*(\d+)\s*[x×]\s*(\d+)\s*$/.exec(env) : null;
-  if (match) {
-    return { width: Number(match[1]), height: Number(match[2]) };
+  const env = process.env.BENCHMARK_VIEWPORT;
+  const match = env ? env.split('x') : null;
+  if (match && match.length === 2) {
+    return { width: Number(match[0]), height: Number(match[1]) };
   }
-  return { width: 1920, height: 1080 };
+  return undefined;
 }
 
-// Determinism flags used for measurement runs. They make timings reproducible
-// but are NOT representative of real performance (`--no-opt` disables the
-// optimizing compiler, `--disable-gpu` forces software rendering), so profiling
-// runs use a lighter set instead.
-const MEASUREMENT_LAUNCH_ARGS = [
-  // V8 flags for deterministic JS execution
-  '--js-flags=--expose-gc,--predictable,--no-opt,--predictable-gc-schedule,--no-concurrent-sweeping,--hash-seed=1,--random-seed=1,--max-old-space-size=4096',
-
-  // Chromium flags to reduce renderer/compositor noise
-  '--disable-background-timer-throttling',
-  '--disable-backgrounding-occluded-windows',
-  '--disable-renderer-backgrounding',
-  '--disable-background-networking',
-  // Reduces environmental noise by disabling field trials,
-  // for more consistent profiling results.
-  '--enable-benchmarking',
-  // Forces software rendering instead of GPU, which is more deterministic.
-  '--disable-gpu',
-];
-
-// Launch args for interactive profiling: keep GC exposed and reduce background
-// throttling noise, but let V8 optimize and the GPU render normally, and open
-// DevTools automatically so the profiler is one click away.
-const PROFILE_LAUNCH_ARGS = [
+// Chromium/V8 launch args shared by measurement and profiling, kept intentionally minimal.
+// `--expose-gc` is required: the harness forces GC between iterations for clean, comparable
+// timings. The backgrounding flags stop Chrome from throttling the (headless or occluded)
+// benchmark tab, which would otherwise add large variance. Heavier "determinism" flags
+// (`--no-opt`, `--predictable`, `--hash-seed`/`--random-seed`, `--disable-gpu`,
+// `--enable-benchmarking`) were measured to slow renders ~40% and distort paint timing without
+// reducing variance, so they are omitted — add them per project via `launchArgs` if a specific
+// workload needs them.
+const LAUNCH_ARGS = [
   '--js-flags=--expose-gc',
   '--disable-background-timer-throttling',
   '--disable-backgrounding-occluded-windows',
   '--disable-renderer-backgrounding',
-  '--auto-open-devtools-for-tabs',
 ];
 
 export function createBenchmarkVitestConfig(
@@ -92,14 +75,15 @@ export function createBenchmarkVitestConfig(
 ): ViteUserConfig {
   const { outputPath, baselinePath, launchArgs = [] } = options ?? {};
   const profile = options?.profile ?? process.env.BENCHMARK_PROFILE === 'true';
-  const profileViewport = resolveProfileViewport(options?.profileViewport);
+  const viewport = resolveViewport(options?.viewport) ?? DEFAULT_VIEWPORT;
 
-  // Size the actual browser window to the viewport too: Vitest's `viewport` only
-  // sizes the test iframe, so without this the headed window stays small and the
-  // full-size iframe is cropped/scrolled instead of filling the window.
+  // Profiling adds DevTools on top of the shared args, plus a window sized to match the viewport —
+  // Vitest's `viewport` only sizes the iframe, so otherwise it's cropped/scrolled in the headed
+  // window instead of filling it. (Measurement is headless, so it has no window to size.)
   const profileArgs = [
-    ...PROFILE_LAUNCH_ARGS,
-    `--window-size=${profileViewport.width},${profileViewport.height}`,
+    ...LAUNCH_ARGS,
+    '--auto-open-devtools-for-tabs',
+    `--window-size=${viewport.width},${viewport.height}`,
   ];
 
   return {
@@ -119,10 +103,8 @@ export function createBenchmarkVitestConfig(
         // Profiling renders into a clean page: hide Vitest's browser runner UI
         // so the orchestrator chrome doesn't clutter what you're profiling.
         ui: profile ? false : undefined,
-        // Vitest's default browser viewport is a phone-sized 414x896. For
-        // profiling, render into a full desktop viewport instead. (Measurement
-        // keeps the default so results stay comparable.)
-        viewport: profile ? profileViewport : undefined,
+        // Same viewport for both modes (DEFAULT_VIEWPORT unless overridden).
+        viewport,
         screenshotFailures: false,
         instances: [
           {
@@ -134,7 +116,7 @@ export function createBenchmarkVitestConfig(
         ],
         provider: playwright({
           launchOptions: {
-            args: [...(profile ? profileArgs : MEASUREMENT_LAUNCH_ARGS), ...launchArgs],
+            args: [...(profile ? profileArgs : LAUNCH_ARGS), ...launchArgs],
           },
         }),
       },


### PR DESCRIPTION
We can simplify the config for measurement case as well. GPU is already disabled in CI, other js engines params seem to have no effect on stability. No need to have desktop viewport only for profiling.

I pulled out the UI part of this while I was trying to understand how the code works. But functionally it doesn't do anything differernt.


### Changes
- **Shared runtime.** The measurement loop and the DevTools profiling session now drive one `createCaseRuntime` (a per-case `mount` / `interact?` / `unmount` / `isMounted` state machine) instead of two parallel flows. The interactive panel moves to its own `profileSession.tsx` (pure DOM, takes an injected runtime).
- **Sentinel ownership.** The `default` Element Timing sentinel is planted by the runtime's `mount()`; measurement pre-wraps `renderFn` in `BenchProfiler`, profiling renders bare so the React Profiler's `onRender` overhead stays out of the hand-captured DevTools trace.
- **Launch args collapsed to one minimal set.** A quick benchmark sweep (3 cases × repeats) showed the V8 determinism flags (`--no-opt`, `--predictable`, seeds) and `--disable-gpu` don't reduce variance — render-time CV is flat across configs, paint CV is equal-or-worse with them, and `--no-opt` costs ~40% render speed. Dropped them from the default; still addable per-project via `launchArgs`.
- **Config surface.** `profile?: boolean` + `viewport?: { width, height }` with a single `1920x1080` default for both modes; env `BENCHMARK_PROFILE` / `BENCHMARK_VIEWPORT`.

